### PR TITLE
Added Support for Ignoring index.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Usage: mongoose-erd-generator [options]
     -V, --version                                                 output the version number
     -p, --path <path>                                             set models path wanted to generate an ERD from.
     -o, --output <path>                                           set output path
+    -i, --ignore-index                                            ignore any files called index.js
     -f, --format [svg,dot,xdot,plain,plan-ext,ps,ps2,json,json0]  
     -c, --color <color>                                           
     -h, --help                                 

--- a/bin/index.js
+++ b/bin/index.js
@@ -15,6 +15,7 @@ const main = async () => {
       .option('-o, --output <path>', 'set output path')
       .option('-f, --format [svg,dot,xdot,plain,plan-ext,ps,ps2,json,json0]')
       .option('-c, --color <color>')
+      .option('-i, --ignore-index','ignore any files called index.js')
       .parse(process.argv);
     if(allowedFormats.indexOf(program.format)==-1){
         console.log(`Format :'${program.format}', is not supported.`);
@@ -27,7 +28,7 @@ const main = async () => {
       const modelsPath = await readdir(modelDirectory);
       const models = [];
       for (const _model of modelsPath) {
-        if (_model.indexOf('.js') != -1) {
+        if (_model.indexOf('.js') != -1 && !(_model === "index.js" && program.ignoreIndex)){
           const model = require(path.join(modelDirectory, _model));
           models.push(model);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-erd-generator",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Many mongoose applications use index.js to populate their applications with the models. I have added the option to ignore the index.js file to allow the modules folder to be scanned without an error occurring